### PR TITLE
Fixing info position

### DIFF
--- a/assets/scripts/css/amy-structure.css
+++ b/assets/scripts/css/amy-structure.css
@@ -200,7 +200,7 @@ Also used by the hover_area div's. Needs to be as big as image was. */
 #info_left_col{
 	float: left;
 	width: 395px;
-	margin: 15.5px 0 0 41.5px;
+	margin: 0 20px 0 auto;
 }
 		
 /*----------MIDDLE COLUMN HOME--------*/
@@ -222,7 +222,7 @@ Also used by the hover_area div's. Needs to be as big as image was. */
 #info_right_col{
 	float: left;
 	width: 395px;
-	margin: 0 20px 0 0;
+	margin: 0 0 0 0;
 }	
 						
 /*----------PROJECT PAGE CONTENT------*/	

--- a/info.html
+++ b/info.html
@@ -30,6 +30,8 @@
  	<div id="content">
 		
         <div id="info_left_col">
+        	<ol class="info_left_list">
+        		<li>
             <div class = "info_hover_area info_left_pic">
                 <div class="info_left_pic find_me">
                     <img src="assets/images/cv_bw.png" class="bw_image" alt="profileimage1"/>
@@ -39,6 +41,8 @@
                         <p>text text text about me MAKE ME BLUE text</p>
                 </div>
             </div>
+          	</li>
+          </ol>
        </div>
 		
        <div id="info_right_col">


### PR DESCRIPTION
There was not symmetry in the two columns and the natural ol/li
formatting was pushing the right column over the edge.

I placed the left column in a list to match the general format of the
site. It is a list with only one element but it is used for sake of a
standard approach. Also, it can be expanded on (more elements added to
left) if needed in the future.

It should be noted that I told Amy this was a bad idea. She was right.
